### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,40 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly Monday 06:15 UTC
+    - cron: "15 6 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Adds `ossf/scorecard-action` workflow that runs weekly (Monday 06:15 UTC) and on push to `main`
- Publishes results to [scorecard.dev](https://scorecard.dev) for public visibility
- Uploads SARIF to the GitHub Security tab for in-repo findings

## Test plan
- [ ] Manually trigger the workflow via Actions → OpenSSF Scorecard → Run workflow
- [ ] Verify SARIF results appear under Security → Code scanning
- [ ] Confirm score is published at `https://scorecard.dev/viewer/?uri=github.com/archgate/check-action`