### PR TITLE
ci: improve OpenSSF Scorecard compliance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @rhuanbarreto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,13 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   update-major-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v1.x    | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it through
+[GitHub's private vulnerability reporting](https://github.com/archgate/check-action/security/advisories/new).
+
+**Please do not open a public issue.**
+
+We will acknowledge your report within 3 business days and aim to release a
+fix within 14 days of confirmation.


### PR DESCRIPTION
## Summary
- Move `contents: write` from top-level to job-level in `release.yml` → fixes **Token-Permissions** (0 → 10)
- Add `SECURITY.md` with vulnerability reporting instructions → fixes **Security-Policy** (0 → 10)
- Add `.github/CODEOWNERS` → fixes the "no codeowners file found" warning in **Branch-Protection**

Dependency pinning and the dependency update tool check will be handled by Renovate (see #2).

## Remaining items (org ruleset — manual)

These require changes to the org-level "main" ruleset (affects all repos):

| Setting | Current | Recommended |
|---|---|---|
| Required approving reviews | 0 | 1 |
| Dismiss stale reviews on push | false | true |
| Require last push approval | false | true |
| Up-to-date branches (strict status checks) | false | true |
| Force push protection | not set | add `non_fast_forward` rule |

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger the Scorecard workflow from Actions tab
- [ ] Verify improved scores at https://scorecard.dev/viewer/?uri=github.com/archgate/check-action