### PR TITLE
fix: replace removed --ci flag with --output github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Archgate Check
 
-Official GitHub Action to run [Archgate](https://archgate.dev) ADR compliance checks on your repository. Automatically installs Archgate and runs `archgate check --ci`, outputting GitHub annotations for any violations.
+Official GitHub Action to run [Archgate](https://archgate.dev) ADR compliance checks on your repository. Automatically installs Archgate and runs `archgate check --output github`, outputting GitHub annotations for any violations.
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -22,4 +22,4 @@ runs:
     - name: Run Archgate Check
       shell: bash
       run: |
-        archgate check --ci
+        archgate check --output github


### PR DESCRIPTION
`check-action` runs `archgate check --ci`, but the CLI removed `--ci` (current flags: `--output/--staged/--base/--adr/--verbose/--strict`). Every repo using this action fails its "Archgate Check" job with `error: unknown option '--ci'` before any rule runs.

`--output github` produces the same GitHub Actions annotations the action promises, and `archgate check` still exits 1 on violations, so CI behavior is unchanged.