### PR TITLE
ci: add Validate Code workflow required by org ruleset

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,95 @@
+name: Validate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate Action
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate action metadata
+        run: |
+          python3 - <<'PY'
+          import sys, yaml
+
+          action = yaml.safe_load(open("action.yml"))
+
+          errors = []
+          for key in ("name", "description", "runs"):
+              if not action.get(key):
+                  errors.append(f"action.yml is missing required key: {key}")
+
+          runs = action.get("runs") or {}
+          if runs.get("using") != "composite":
+              errors.append(f"action.yml runs.using must be 'composite', got {runs.get('using')!r}")
+
+          for i, step in enumerate(runs.get("steps") or []):
+              if "run" in step and not step.get("shell"):
+                  errors.append(f"action.yml step {i} ({step.get('name', 'unnamed')}) has 'run' without 'shell'")
+
+          for e in errors:
+              print(f"::error file=action.yml::{e}")
+          sys.exit(1 if errors else 0)
+          PY
+
+      - name: Verify all actions are pinned to a full commit SHA
+        run: |
+          python3 - <<'PY'
+          import pathlib, re, sys, yaml
+
+          SHA = re.compile(r"^[0-9a-f]{40}$")
+          failures = []
+
+          def check(path, node):
+              if isinstance(node, dict):
+                  uses = node.get("uses")
+                  if isinstance(uses, str) and not uses.startswith(("./", "docker://")):
+                      ref = uses.partition("@")[2]
+                      if not SHA.match(ref):
+                          failures.append(f"{path}: '{uses}' is not pinned to a full commit SHA")
+                  for value in node.values():
+                      check(path, value)
+              elif isinstance(node, list):
+                  for value in node:
+                      check(path, value)
+
+          paths = [pathlib.Path("action.yml"), *sorted(pathlib.Path(".github/workflows").glob("*.yml"))]
+          for path in paths:
+              check(path, yaml.safe_load(path.read_text()))
+
+          for f in failures:
+              print(f"::error::{f}")
+          print(f"Checked {len(paths)} file(s).")
+          sys.exit(1 if failures else 0)
+          PY
+
+  # Gate job — single required status check for the org ruleset.
+  status:
+    name: Validate Code
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [validate]
+    steps:
+      - name: Check job results
+        run: |
+          if [[ "${{ needs.validate.result }}" != "success" ]]; then
+            echo "::error::Validation failed: ${{ needs.validate.result }}"
+            exit 1
+          fi
+          echo "All checks passed."


### PR DESCRIPTION
The archgate org ruleset requires a `Validate Code` status check on every PR into `main`. This repository had no CI workflow at all, so that check never reported and **every** pull request was permanently blocked (`mergeStateStatus: BLOCKED`) even with an approving review and all other checks green.

This adds the same gate-job pattern already used by `archgate/pre-commit-hook`, with validation appropriate for a composite-action repo:

- **`action.yml` metadata** — required keys present, `runs.using` is `composite`, and no `run` step is missing its `shell`.
- **SHA pinning** — every `uses:` in `action.yml` and in `.github/workflows/*.yml` must be pinned to a full 40-character commit SHA. This is exactly what the Renovate PRs in this repo touch, and it matches the pinning posture the Scorecard workflow already enforces.
- **`Validate Code`** — the gate job the org ruleset requires.

Both scripts were run against this repo before pushing (pass) and against a deliberately unpinned `actions/checkout@v4` (fails as expected).