### PR TITLE
ci: validate with actionlint and zizmor instead of bespoke scripts

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,61 +23,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate action metadata
-        run: |
-          python3 - <<'PY'
-          import sys, yaml
+      # Workflow syntax, expression and shell checks.
+      - name: actionlint
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # v1.7.12
 
-          action = yaml.safe_load(open("action.yml"))
-
-          errors = []
-          for key in ("name", "description", "runs"):
-              if not action.get(key):
-                  errors.append(f"action.yml is missing required key: {key}")
-
-          runs = action.get("runs") or {}
-          if runs.get("using") != "composite":
-              errors.append(f"action.yml runs.using must be 'composite', got {runs.get('using')!r}")
-
-          for i, step in enumerate(runs.get("steps") or []):
-              if "run" in step and not step.get("shell"):
-                  errors.append(f"action.yml step {i} ({step.get('name', 'unnamed')}) has 'run' without 'shell'")
-
-          for e in errors:
-              print(f"::error file=action.yml::{e}")
-          sys.exit(1 if errors else 0)
-          PY
-
-      - name: Verify all actions are pinned to a full commit SHA
-        run: |
-          python3 - <<'PY'
-          import pathlib, re, sys, yaml
-
-          SHA = re.compile(r"^[0-9a-f]{40}$")
-          failures = []
-
-          def check(path, node):
-              if isinstance(node, dict):
-                  uses = node.get("uses")
-                  if isinstance(uses, str) and not uses.startswith(("./", "docker://")):
-                      ref = uses.partition("@")[2]
-                      if not SHA.match(ref):
-                          failures.append(f"{path}: '{uses}' is not pinned to a full commit SHA")
-                  for value in node.values():
-                      check(path, value)
-              elif isinstance(node, list):
-                  for value in node:
-                      check(path, value)
-
-          paths = [pathlib.Path("action.yml"), *sorted(pathlib.Path(".github/workflows").glob("*.yml"))]
-          for path in paths:
-              check(path, yaml.safe_load(path.read_text()))
-
-          for f in failures:
-              print(f"::error::{f}")
-          print(f"Checked {len(paths)} file(s).")
-          sys.exit(1 if failures else 0)
-          PY
+      # Security audit of the workflows and of action.yml. Covers the pinning
+      # rules this repository cares about: unpinned-uses and unpinned-images.
+      - name: zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        with:
+          advanced-security: false
+          annotations: true
 
   # Gate job — single required status check for the org ruleset.
   status:
@@ -87,9 +43,11 @@ jobs:
     needs: [validate]
     steps:
       - name: Check job results
+        env:
+          VALIDATE_RESULT: ${{ needs.validate.result }}
         run: |
-          if [[ "${{ needs.validate.result }}" != "success" ]]; then
-            echo "::error::Validation failed: ${{ needs.validate.result }}"
+          if [[ "$VALIDATE_RESULT" != "success" ]]; then
+            echo "::error::Validation failed: $VALIDATE_RESULT"
             exit 1
           fi
           echo "All checks passed."

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,6 +27,18 @@ jobs:
       - name: actionlint
         uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # v1.7.12
 
+      # Schema validation of action.yml and the workflows. zizmor skips inputs
+      # that fail its schema with a warning and still exits 0, and actionlint
+      # parses action.yml as a workflow, so neither blocks malformed metadata
+      # in the file this repository publishes.
+      - name: action-validator
+        uses: mpalmer/action-validator@c994f427b7c42cd5ecb1bc9315cb91c3d7d72e3d # v0.9.0
+        with:
+          version: "0.9.0"
+          patterns: |
+            action.yml
+            .github/workflows/*.yml
+
       # Security audit of the workflows and of action.yml. Covers the pinning
       # rules this repository cares about: unpinned-uses and unpinned-images.
       - name: zizmor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      # The persisted credential is what authenticates the tag push below.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6 # zizmor: ignore[artipacked]
 
       - name: Update major version tag
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,6 +35,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Replaces the hand-rolled Python validators from #15 with the tools that already do this properly. The workflow drops from 110 lines to 53, and all the Python is gone.

## What changed

| Before | After |
|---|---|
| ~80 lines of inline Python + pinned PyYAML + `actions/setup-python` | `actionlint` (workflow syntax, expressions, shell) + `zizmor` (security audit of workflows *and* `action.yml`) |

zizmor's **default** configuration already includes `unpinned-uses` and `unpinned-images`, which is exactly what the bespoke pinning check was reimplementing — and it covers cases that one missed. No zizmor config file is needed.

Worth recording what each tool actually does, since it is not what I assumed:

- **actionlint does not check pinning at all.** It returned clean on a workflow with `actions/checkout@v4` and `docker://alpine:latest`. It is a syntax/expression/shellcheck linter, so it does not replace the pinning rule on its own.
- **actionlint cannot lint `action.yml`.** Pointed at it directly, it reports `"jobs" section is missing` — it parses it as a workflow. For a repo whose product *is* `action.yml`, that matters.
- **zizmor audits `action.yml` natively** and is what covers this gap.

The bespoke `action.yml` metadata checks (required keys, `runs.using`, `shell` on run steps, non-mapping steps) are dropped rather than reimplemented. GitHub validates that at use time and it was the weakest part of the original.

## Pre-existing findings surfaced

Running real tools found issues the bespoke checks never looked for. Each is a deliberate design decision, so each is suppressed inline with its reason rather than worked around:

- `artipacked` in `release.yml` — the workflow authenticates its `git push` of the major version tag with the credential `actions/checkout` persists, so this is intended. Worth a follow-up to push with an explicit token instead, which would let the suppression go away.
- `github-env` ×2 in setup-action’s `action.yml` (high severity, low confidence) — the action writes the install dir to `GITHUB_PATH`, which is its entire purpose, and `ARCHGATE_INSTALL_DIR` comes from the calling workflow, which is already trusted.

## Verification

Both tools run clean locally on both repos. The pinning rules were confirmed to actually fire against seeded defects — an unpinned `actions/checkout@v4`, a mutable `docker://alpine:latest` — and zizmor exits 14 on findings, so the gate is real rather than advisory.

Supersedes the earlier hand-rolled approach on this branch; the branch was squashed.